### PR TITLE
Adapted for Python 3

### DIFF
--- a/auto_ghost.py
+++ b/auto_ghost.py
@@ -19,7 +19,7 @@ def set_nick(word, word_eol, userdata):
     password = xchat.get_info("nickserv")
     
     if word[3] == desired_nick and password:
-        randstring = ''.join(choice(string.lowercase) for i in xrange(16))
+        randstring = ''.join(choice(string.ascii_lowercase) for i in range(16))
         xchat.command("nick %s" % randstring)
         xchat.command("nickserv ghost %s %s" % (desired_nick, password))
         xchat.command("nick %s" % desired_nick)


### PR DESCRIPTION
That line works on both Python 2.7.8 (cygwin) and Python 3.4.1 (installed with hexchat).
The extra memory consumption on python 2 from using range instead of xrange is negligible.
